### PR TITLE
Do not ignore 'cryptoauthlib/app' path

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,8 +1,7 @@
-cryptoauthlib/app/
 cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/
-cryptoauthlib/test/cmd-processor.c
+cryptoauthlib/test/*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*


### PR DESCRIPTION
Do not ignore 'app' directory since it provides the interface for constructing X509 certificates and more.

- The content of the 'app' directory being used by the provisioning team