### PR TITLE
Modify mbed ignore

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,4 +1,5 @@
-cryptoauthlib/app/
+cryptoauthlib/app/secure_boot/
+cryptoauthlib/app/ip_protecton/
 cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/


### PR DESCRIPTION
Do not ignore 'app' directory since it provides the interface for constructing X509 certificates and more.

- The content of the 'app' directory being used by the provisioning team