### PR TITLE
Ignore unity files

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,7 +1,8 @@
 cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/
-cryptoauthlib/test/*
+cryptoauthlib/test/cmd-processor.c
+cryptoauthlib/test/unity*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*

--- a/.mbedignore
+++ b/.mbedignore
@@ -1,8 +1,7 @@
-cryptoauthlib/app/
 cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/
-cryptoauthlib/test/cmd-processor.c
+cryptoauthlib/test/*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*


### PR DESCRIPTION
Ignore untity files, as main application may use its own unity.
In case of MCCE, mbed-os compiles its own untity vesion and we need to ignore these files to avoid compilation errors.