### PR TITLE
Ignore test unity files

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -3,6 +3,7 @@ cryptoauthlib/docs/
 cryptoauthlib/python/
 cryptoauthlib/third_party/
 cryptoauthlib/test/cmd-processor.c
+cryptoauthlib/test/unity*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*


### PR DESCRIPTION
Mbed OS already includes its own copy of Unity. Ignore the copy provided
by cryptoauthlib.

This is a copy of https://github.com/ARMmbed/mbed-cryptoauthlib/pull/6 with some typos in the commit message fixed, an explanation added in the commit messaged, and the author email updated.