### PR TITLE
Ignore cryptoauthlib/test directory

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -2,9 +2,8 @@ cryptoauthlib/app/secure_boot/
 cryptoauthlib/app/ip_protecton/
 cryptoauthlib/docs/
 cryptoauthlib/python/
+cryptoauthlib/test/
 cryptoauthlib/third_party/
-cryptoauthlib/test/cmd-processor.c
-cryptoauthlib/test/unity*
 cryptoauthlib/lib/hal/hal_*
 cryptoauthlib/lib/hal/i2c_*
 cryptoauthlib/lib/hal/kit_*


### PR DESCRIPTION
After the fix https://jira.arm.com/browse/IOTCRYPT-949, mbed ignore of test/unity* is not good enough.
Our applications provide this error with ARMC6
 
[Error] @0,0: L6218E: Undefined symbol UnityTestRunner (referred from BUILD/K64F/ARMC6/mbed-os-atecc608/mbed-cryptoauthlib/cryptoauthlib/test/atca_tests_aes.o).