### PR TITLE
Ignore cryptoauthlib/app/api_206a directory

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,3 +1,4 @@
+cryptoauthlib/app/api_206a/
 cryptoauthlib/app/secure_boot/
 cryptoauthlib/app/ip_protecton/
 cryptoauthlib/docs/


### PR DESCRIPTION
These files currently have trouble compiling with IAR, so ignore them for now.