### PR TITLE
Remove wait deprecated API

### DIFF
--- a/source/hal_mbed.cpp
+++ b/source/hal_mbed.cpp
@@ -54,7 +54,7 @@ void atca_delay_10us(uint32_t delay) {
 
 void atca_delay_ms(uint32_t delay) {
     // tr_debug("delay_ms %lu", delay);
-    wait_ms(delay);
+    thread_sleep_for(delay);
 }
 
 /** \brief hal_i2c_init manages requests to initialize a physical interface.  it manages use counts so when an interface


### PR DESCRIPTION
`wait` and `wait_ms` are removed from Mbed OS source in the [PR#12572](https://github.com/ARMmbed/mbed-os/pull/12572), so modified source to use thread_sleep_for API.

### Reviewers <!-- Optional -->
@evedon, @Patater